### PR TITLE
Check for team assignment before assigning

### DIFF
--- a/src/main/java/rip/bolt/ingame/team/ColorTeamSetup.java
+++ b/src/main/java/rip/bolt/ingame/team/ColorTeamSetup.java
@@ -51,10 +51,9 @@ public class ColorTeamSetup implements TeamSetup {
 
         for (Team team : teams) {
             TournamentTeam colourTeam = colorTeams.get(team.getColor());
-            if (colourTeam != null) {
+            if (colourTeam != null && !this.assigned.containsKey(colourTeam)) {
                 //team with that colour, lets assign the
                 assignTeam(team, colourTeam);
-                //colorTeams.remove(team.getColor());
                 continue;
             }
 
@@ -76,20 +75,25 @@ public class ColorTeamSetup implements TeamSetup {
                 .filter(Objects::nonNull)
                 .filter(x -> !assigned.containsKey(x))
                 .forEach(unassigned::add);
-
-        //colorTeams.clear();
     }
 
     private void assignLeftovers(List<Team> leftoverTeams) {
+        Iterator<TournamentTeam> teamIterator = unassigned.iterator();
         for (Team leftover : leftoverTeams) {
             if (unassigned.isEmpty()) {
                 return;
             }
 
-            TournamentTeam selected = unassigned.iterator().next();
-            unassigned.remove(selected);
-            assignTeam(leftover, selected);
+            while (teamIterator.hasNext()) {
+                TournamentTeam selected = teamIterator.next();
+                if (!assigned.containsKey(selected)) {
+                    assignTeam(leftover, selected);
+                    break;
+                }
+            }
         }
+
+        assigned.keySet().forEach(unassigned::remove);
     }
 
     private void reset() {
@@ -98,7 +102,7 @@ public class ColorTeamSetup implements TeamSetup {
             TournamentTeam deleted = colorTeams.put(team.getColor(), tournamentTeam);
 
             //there should never be a duplicate but just in case remove it here
-            if (deleted != null && !deleted.getName().equals(tournamentTeam.getName())) {
+            if (deleted != null && !deleted.equals(tournamentTeam)) {
                 //team used to have this colour, doesn't anymore
                 unassigned.add(deleted);
             }


### PR DESCRIPTION
Seemed to be a case of teams being assigned without any checks to if the were already assigned.
This happened in two places for team assignment and unassigned team assignment 😿 .

Would be made a lot nicer with the one check when assigning teams.
```java
if (colourTeam != null && !this.assigned.containsKey(colourTeam)) {
```
*BUT* I was told by a wise man there was a case where [ColorTeamSetup.java#L100](https://github.com/bolt-rip/ingame/blob/master/src/main/java/rip/bolt/ingame/team/ColorTeamSetup.java#L100) could fix issues so the extra steps in `assignLeftovers` were needed too.

I told @mattarnold98 that this wasn't very pretty but he just laughed at me and told me to keep typing against my will.

This also removes a few commented out lines just to clear up any confusion they may cause in the future.

![image](https://user-images.githubusercontent.com/8608892/87977979-8a8cb000-cac7-11ea-9db3-54452222fe01.png)
