### PR TITLE
Add loaded state with null checks

### DIFF
--- a/src/main/java/rip/bolt/ingame/ranked/MatchStatus.java
+++ b/src/main/java/rip/bolt/ingame/ranked/MatchStatus.java
@@ -2,6 +2,7 @@ package rip.bolt.ingame.ranked;
 
 public enum MatchStatus {
   CREATED,
+  LOADED,
   STARTED,
   ENDED,
   CANCELLED;
@@ -11,7 +12,9 @@ public enum MatchStatus {
   public boolean canTransitionTo(MatchStatus next) {
     switch (this) {
       case CREATED:
-        return true;
+        return next == LOADED;
+      case LOADED:
+        return next == STARTED;
       case STARTED:
         return next == ENDED || next == CANCELLED;
       case ENDED:


### PR DESCRIPTION
Adds loaded state and transition to it.

Prevents posting match data (which now happens on map load) when a Bolt match does not exist.