### PR TITLE
Add manual cancel flag to prevent banning players

### DIFF
--- a/src/main/java/rip/bolt/ingame/commands/RankedAdminCommands.java
+++ b/src/main/java/rip/bolt/ingame/commands/RankedAdminCommands.java
@@ -2,6 +2,7 @@ package rip.bolt.ingame.commands;
 
 import static tc.oc.pgm.lib.net.kyori.adventure.text.Component.text;
 
+import java.time.Duration;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.CommandSender;
 import rip.bolt.ingame.api.definitions.BoltMatch;
@@ -104,13 +105,13 @@ public class RankedAdminCommands {
       throw new CommandException(ChatColor.RED + "Unable to transition to the cancelled state.");
     }
 
-    ranked.postMatchStatus(match, MatchStatus.CANCELLED);
+    ranked.manualCancel(match);
 
     if (match.getPhase().equals(MatchPhase.STARTING)) {
       match.getCountdown().cancelAll();
     }
 
-    boolean running = match.getPhase().equals(MatchPhase.RUNNING);
+    boolean running = match.getPhase().canTransitionTo(MatchPhase.FINISHED);
     if (running) {
       match.addVictoryCondition(new TieVictoryCondition());
       match.finish();
@@ -125,7 +126,7 @@ public class RankedAdminCommands {
 
     if (!running) {
       Audience.get(match.getCompetitors()).sendMessage(Messages.requeue());
-      ranked.manualPoll(true);
+      ranked.getPoll().startIn(Duration.ofSeconds(15));
     }
   }
 }

--- a/src/main/java/rip/bolt/ingame/commands/RequeueCommands.java
+++ b/src/main/java/rip/bolt/ingame/commands/RequeueCommands.java
@@ -31,8 +31,6 @@ public class RequeueCommands {
       throw new CommandException(
           ChatColor.RED + "You may only run this command after a match has ended.");
 
-    sender.sendMessage(text("Request to requeue has been sent.", NamedTextColor.GRAY));
-
     Ingame.newChain()
         .asyncFirst(() -> Ingame.get().getApiManager().postPlayerRequeue(sender.getId()))
         .syncLast(response -> sendResponse(sender, response))

--- a/src/main/java/rip/bolt/ingame/ranked/PlayerWatcher.java
+++ b/src/main/java/rip/bolt/ingame/ranked/PlayerWatcher.java
@@ -78,6 +78,8 @@ public class PlayerWatcher implements Listener {
 
   @EventHandler(priority = EventPriority.LOW)
   public void onMatchEnd(MatchFinishEvent event) {
+    if (rankedManager.isManuallyCanceled()) return;
+
     if (event.getMatch().getDuration().compareTo(ABSENT_MAX) > 0) {
       this.absentLengths.forEach((key, value) -> updateAbsenceLengths(key));
 
@@ -87,15 +89,14 @@ public class PlayerWatcher implements Listener {
               .map(Map.Entry::getKey)
               .collect(Collectors.toList());
 
-      if (absentPlayers.size() > 0) {
-        event
-            .getMatch()
-            .sendMessage(
-                text(
-                    "A player was a temporarily banned due to lack of participation. "
-                        + "As the match was unbalanced it will take less of an effect on player scores.",
-                    NamedTextColor.GRAY));
-      }
+      if (!playersAbandoned(absentPlayers)) return;
+
+      event
+          .getMatch()
+          .sendMessage(
+              text(
+                  "Player(s) temporarily banned due to lack of participation.",
+                  NamedTextColor.GRAY));
     }
   }
 

--- a/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
@@ -42,6 +42,7 @@ public class RankedManager implements Listener {
   private BoltMatch match;
 
   private Duration cycleTime = Duration.ofSeconds(0);
+  private boolean manuallyCanceled;
 
   public RankedManager() {
 
@@ -57,6 +58,7 @@ public class RankedManager implements Listener {
     if (!this.isMatchValid(match)) return;
 
     this.match = match;
+    this.manuallyCanceled = false;
     poll.stop();
 
     Tournament.get().getTeamManager().clear();
@@ -132,6 +134,15 @@ public class RankedManager implements Listener {
 
   public void manualReset() {
     this.match = null;
+  }
+
+  public void manualCancel(Match match) {
+    this.manuallyCanceled = true;
+    this.postMatchStatus(match, MatchStatus.CANCELLED);
+  }
+
+  public boolean isManuallyCanceled() {
+    return manuallyCanceled;
   }
 
   @EventHandler


### PR DESCRIPTION
Adds manually cancelled flag so bans do not occur when a match is manually cancelled by a staff member.