### PR TITLE
Add link to match stats on match end

### DIFF
--- a/src/main/java/rip/bolt/ingame/commands/RankedAdminCommands.java
+++ b/src/main/java/rip/bolt/ingame/commands/RankedAdminCommands.java
@@ -11,6 +11,7 @@ import org.bukkit.entity.Player;
 import rip.bolt.ingame.Ingame;
 import rip.bolt.ingame.api.definitions.BoltMatch;
 import rip.bolt.ingame.api.definitions.Punishment;
+import rip.bolt.ingame.config.AppData;
 import rip.bolt.ingame.ranked.MatchStatus;
 import rip.bolt.ingame.ranked.RankedManager;
 import rip.bolt.ingame.utils.Messages;
@@ -78,7 +79,9 @@ public class RankedAdminCommands {
     if (boltMatch == null)
       throw new CommandException(ChatColor.RED + "No Bolt match currently loaded.");
 
-    Audience.get(sender).sendMessage(text(boltMatch.toString(), NamedTextColor.GRAY));
+    Audience audience = Audience.get(sender);
+    audience.sendMessage(text(boltMatch.toString(), NamedTextColor.GRAY));
+    if (AppData.Web.getMatch() != null) audience.sendMessage(Messages.matchLink(boltMatch));
   }
 
   @Command(

--- a/src/main/java/rip/bolt/ingame/config/AppData.java
+++ b/src/main/java/rip/bolt/ingame/config/AppData.java
@@ -22,6 +22,17 @@ public class AppData {
     }
   }
 
+  public static class Web {
+
+    public static String getMatch() {
+      return Ingame.get().getConfig().getString("web.match", null);
+    }
+
+    public static String getProfile() {
+      return Ingame.get().getConfig().getString("web.profile", null);
+    }
+  }
+
   public static long absentSecondsLimit() {
     return Ingame.get().getConfig().getLong("absence-time-seconds", 120);
   }

--- a/src/main/java/rip/bolt/ingame/ranked/RankManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/RankManager.java
@@ -1,5 +1,6 @@
 package rip.bolt.ingame.ranked;
 
+import static tc.oc.pgm.lib.net.kyori.adventure.text.Component.empty;
 import static tc.oc.pgm.lib.net.kyori.adventure.text.Component.text;
 
 import java.util.ArrayList;
@@ -21,8 +22,11 @@ import rip.bolt.ingame.api.definitions.MatchResult;
 import rip.bolt.ingame.api.definitions.Participation;
 import rip.bolt.ingame.api.definitions.Team;
 import rip.bolt.ingame.api.definitions.User;
+import rip.bolt.ingame.config.AppData;
+import rip.bolt.ingame.utils.Messages;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.event.NameDecorationChangeEvent;
+import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchManager;
 import tc.oc.pgm.api.match.event.MatchStatsEvent;
 import tc.oc.pgm.api.party.Competitor;
@@ -86,9 +90,13 @@ public class RankManager implements Listener {
 
     if (updates.isEmpty()) return;
 
-    Bukkit.getServer()
-        .getPluginManager()
-        .callEvent(new MatchStatsEvent(updates.get(0).player.getMatch(), true, true));
+    Match match = updates.get(0).player.getMatch();
+    Bukkit.getServer().getPluginManager().callEvent(new MatchStatsEvent(match, true, true));
+
+    if (AppData.Web.getMatch() != null) {
+      match.sendMessage(Messages.matchLink(newMatch));
+      match.sendMessage(empty());
+    }
 
     updates.forEach(update -> notifyUpdate(update.old, update.updated, update.player));
   }

--- a/src/main/java/rip/bolt/ingame/utils/Components.java
+++ b/src/main/java/rip/bolt/ingame/utils/Components.java
@@ -27,6 +27,14 @@ public class Components {
                 .append(Component.text(command, style)));
   }
 
+  public static Component link(Style style, String url) {
+    return Component.text(url, style)
+        .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, url))
+        .hoverEvent(
+            Component.text("Click to visit ", NamedTextColor.YELLOW)
+                .append(Component.text(url, style)));
+  }
+
   static String toArgument(String input) {
     if (input == null) return null;
     return input.replace(" ", "┈");

--- a/src/main/java/rip/bolt/ingame/utils/Messages.java
+++ b/src/main/java/rip/bolt/ingame/utils/Messages.java
@@ -1,9 +1,13 @@
 package rip.bolt.ingame.utils;
 
 import static rip.bolt.ingame.utils.Components.command;
+import static rip.bolt.ingame.utils.Components.link;
 import static tc.oc.pgm.lib.net.kyori.adventure.text.Component.newline;
 import static tc.oc.pgm.lib.net.kyori.adventure.text.Component.text;
 
+import rip.bolt.ingame.api.definitions.BoltMatch;
+import rip.bolt.ingame.config.AppData;
+import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.lib.net.kyori.adventure.text.Component;
 import tc.oc.pgm.lib.net.kyori.adventure.text.format.NamedTextColor;
 import tc.oc.pgm.lib.net.kyori.adventure.text.format.Style;
@@ -24,5 +28,19 @@ public class Messages {
                 .append(
                     command(
                         Style.style(NamedTextColor.YELLOW, TextDecoration.UNDERLINED), "forfeit")));
+  }
+
+  public static Component matchLink(BoltMatch match) {
+    String url = AppData.Web.getMatch().replace("{matchId}", match.getId());
+
+    return text("Match link: ", NamedTextColor.WHITE)
+        .append(link(Style.style(NamedTextColor.BLUE, TextDecoration.UNDERLINED), url));
+  }
+
+  public static Component profileLink(MatchPlayer player) {
+    String url = AppData.Web.getProfile().replace("{name}", player.getNameLegacy());
+
+    return text("Profile link: ", NamedTextColor.WHITE)
+        .append(link(Style.style(NamedTextColor.BLUE, TextDecoration.UNDERLINED), url));
   }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,6 +15,12 @@ allow-forfeit: true
 # duration to countdown before starting match
 match-start-duration: "300s"
 
+# website page links (remove section to remove references)
+web:
+  match: https://localhost:3000/matches/{matchId}
+  profile: https://localhost:3000/{name}
+
+# api connection details
 api:
   url: https://localhost:3000/v1/
   key: authorisation-key


### PR DESCRIPTION
Adds a website match link along with the other stats on match end (for quick and easy access).

Displays between match stats and bolt stats and shows to all players on the server.

![image](https://user-images.githubusercontent.com/8608892/113192350-8cae2d80-9256-11eb-95ec-ddaca83f4c68.png)


