### PR TITLE
Add custom tab manager for team MMR display

### DIFF
--- a/src/main/java/rip/bolt/ingame/Ingame.java
+++ b/src/main/java/rip/bolt/ingame/Ingame.java
@@ -38,7 +38,7 @@ public class Ingame extends JavaPlugin {
 
     apiManager = new APIManager();
 
-    rankedManager = new RankedManager();
+    rankedManager = new RankedManager(this);
 
     Bukkit.getPluginManager().registerEvents(rankedManager, this);
     Bukkit.getPluginManager().registerEvents(rankedManager.getPlayerWatcher(), this);

--- a/src/main/java/rip/bolt/ingame/config/AppData.java
+++ b/src/main/java/rip/bolt/ingame/config/AppData.java
@@ -56,4 +56,8 @@ public class AppData {
   public static Duration matchStartDuration() {
     return parseDuration(Ingame.get().getConfig().getString("match-start-duration", "180s"));
   }
+
+  public static boolean customTabEnabled() {
+    return Ingame.get().getConfig().getBoolean("custom-tab-enabled", true);
+  }
 }

--- a/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
@@ -21,6 +21,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
 import rip.bolt.ingame.Ingame;
 import rip.bolt.ingame.api.definitions.BoltMatch;
 import rip.bolt.ingame.api.definitions.Team;
@@ -40,6 +41,7 @@ public class RankedManager implements Listener {
   private final PlayerWatcher playerWatcher;
   private final RankManager rankManager;
   private final StatsManager statsManager;
+  private final TabManager tabManager;
   private final MatchSearch poll;
 
   private TournamentFormat format;
@@ -48,10 +50,11 @@ public class RankedManager implements Listener {
   private Duration cycleTime = Duration.ofSeconds(0);
   private boolean manuallyCanceled;
 
-  public RankedManager() {
+  public RankedManager(Plugin plugin) {
     playerWatcher = new PlayerWatcher(this);
     rankManager = new RankManager(this);
     statsManager = new StatsManager(this);
+    tabManager = new TabManager(plugin);
     MatchPreloader.create();
 
     poll = new MatchSearch(this::setupMatch);

--- a/src/main/java/rip/bolt/ingame/ranked/TabManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/TabManager.java
@@ -1,0 +1,37 @@
+package rip.bolt.ingame.ranked;
+
+import org.bukkit.plugin.Plugin;
+import rip.bolt.ingame.config.AppData;
+import rip.bolt.ingame.utils.RankedTeamTabEntry;
+import tc.oc.pgm.tablist.FreeForAllTabEntry;
+import tc.oc.pgm.tablist.MapTabEntry;
+import tc.oc.pgm.tablist.MatchFooterTabEntry;
+import tc.oc.pgm.tablist.MatchTabManager;
+import tc.oc.pgm.util.tablist.PlayerTabEntry;
+
+public class TabManager {
+
+  public TabManager(Plugin plugin) {
+
+    IngameTabManager matchTabManager;
+
+    if (AppData.customTabEnabled()) {
+      matchTabManager = new IngameTabManager(plugin);
+      plugin.getServer().getPluginManager().registerEvents(matchTabManager, plugin);
+    }
+  }
+
+  public static class IngameTabManager extends MatchTabManager {
+
+    public IngameTabManager(Plugin plugin) {
+      super(
+          plugin,
+          PlayerTabEntry::new,
+          RankedTeamTabEntry::new,
+          MapTabEntry::new,
+          MatchTabManager::headerFactory,
+          MatchFooterTabEntry::new,
+          FreeForAllTabEntry::new);
+    }
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,6 +17,9 @@ forfeit:
 # duration to countdown before starting match
 match-start-duration: "300s"
 
+# if custom tab list should be used
+custom-tab-enabled: true
+
 # website page links (remove section to remove references)
 web:
   match: https://localhost:3000/matches/{matchId}


### PR DESCRIPTION
Replicate PGM tab logic moving MMR displays to ingame.

![image](https://user-images.githubusercontent.com/8608892/124383186-e9d8d580-dcc2-11eb-96e9-fd0fb8bab492.png)