### PR TITLE
Grab bowDamageTaken statistic from PGM

### DIFF
--- a/src/main/java/rip/bolt/ingame/api/definitions/Stats.java
+++ b/src/main/java/rip/bolt/ingame/api/definitions/Stats.java
@@ -12,6 +12,7 @@ public class Stats {
   private double damageDealt;
   private double damageDealtBow;
   private double damageReceived;
+  private double damageReceivedBow;
   private int arrowsHit;
   private int arrowsShot;
 
@@ -24,6 +25,7 @@ public class Stats {
       double damageDealt,
       double damageDealtBow,
       double damageReceived,
+      double damageReceivedBow,
       int arrowsHit,
       int arrowsShot) {
     this.kills = kills;
@@ -32,6 +34,7 @@ public class Stats {
     this.damageDealt = damageDealt;
     this.damageDealtBow = damageDealtBow;
     this.damageReceived = damageReceived;
+    this.damageReceivedBow = damageReceivedBow;
     this.arrowsHit = arrowsHit;
     this.arrowsShot = arrowsShot;
   }
@@ -82,6 +85,14 @@ public class Stats {
 
   public void setDamageReceived(double damageReceived) {
     this.damageReceived = damageReceived;
+  }
+
+  public double getDamageReceivedBow() {
+    return damageReceivedBow;
+  }
+
+  public void setDamageReceivedBow(double damageReceivedBow) {
+    this.damageReceivedBow = damageReceivedBow;
   }
 
   public int getArrowsHit() {

--- a/src/main/java/rip/bolt/ingame/ranked/StatsManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/StatsManager.java
@@ -39,6 +39,7 @@ public class StatsManager implements Listener {
             stats.getDamageDone(),
             stats.getBowDamage(),
             stats.getDamageTaken(),
+            stats.getBowDamageTaken(),
             stats.getShotsHit(),
             stats.getShotsTaken()));
   }


### PR DESCRIPTION
**Depends on https://github.com/PGMDev/PGM/pull/951**

This PR ensures that Ingame also accounts for the bowDamageTaken statistic in PGM, added in the above PR (though it has not been merged yet).

I'm unsure of what implications this will have for already collected and recorded statistics with the current behaviour, which is to count all damage received as one statistic without differentiation between melee or bow damage.