### PR TITLE
Rework match cancel reason logic

### DIFF
--- a/src/main/java/rip/bolt/ingame/ranked/CancelManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/CancelManager.java
@@ -43,13 +43,14 @@ public class CancelManager {
   }
 
   public void playerJoined(MatchPlayer player) {
-    if (countdown == null || !countdown.players.contains(player.getId())) return;
+    if (countdown == null || !countdown.contains(player.getId())) return;
 
     // Remove player from countdown
     countdown.removePlayer(player.getId());
-    if (countdown.isEmpty()) clearCountdown();
-
-    startCountdownIfRequired(player.getMatch());
+    if (countdown.isEmpty()) {
+      clearCountdown();
+      startCountdownIfRequired(player.getMatch());
+    }
   }
 
   public void startCountdown(Match match, List<UUID> players, @Nullable Duration duration) {
@@ -60,9 +61,9 @@ public class CancelManager {
             this, match, players, duration == null ? CANCEL_ABSENCE_LENGTH : duration);
   }
 
-  public void startCountdownIfRequired(Match match) {
+  private void startCountdownIfRequired(Match match) {
     // Check if countdown can be started
-    if (countdown != null || !canCancel(match)) return;
+    if (!canCancel(match)) return;
 
     // Check if countdown required for any participants
     PlayerWatcher.MatchParticipation participation =
@@ -75,7 +76,7 @@ public class CancelManager {
             .orElse(null);
 
     if (participation == null
-        || (countdown != null && countdown.players.contains(participation.getUUID()))) return;
+        || (countdown != null && countdown.contains(participation.getUUID()))) return;
 
     Duration duration =
         Ordering.natural()
@@ -133,12 +134,16 @@ public class CancelManager {
       duration--;
     }
 
+    public boolean contains(UUID player) {
+      return players.contains(player);
+    }
+
     public boolean isEmpty() {
       return players.isEmpty();
     }
 
     public void removePlayer(UUID player) {
-      if (players.remove(player) && players.isEmpty()) cancelCountdown();
+      players.remove(player);
     }
 
     public void cancelCountdown() {

--- a/src/main/java/rip/bolt/ingame/ranked/CancelManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/CancelManager.java
@@ -75,8 +75,8 @@ public class CancelManager {
             .max(Comparator.comparing(PlayerWatcher.MatchParticipation::currentAbsentDuration))
             .orElse(null);
 
-    if (participation == null
-        || (countdown != null && countdown.contains(participation.getUUID()))) return;
+    if (participation == null || (countdown != null && countdown.contains(participation.getUUID())))
+      return;
 
     Duration duration =
         Ordering.natural()

--- a/src/main/java/rip/bolt/ingame/ranked/CancelManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/CancelManager.java
@@ -43,13 +43,8 @@ public class CancelManager {
   }
 
   public void playerJoined(MatchPlayer player) {
-    if (countdown == null || !countdown.players.contains(player.getId())) return;
-
-    // Remove player from countdown
-    countdown.removePlayer(player.getId());
-    if (countdown.isEmpty()) clearCountdown();
-
-    startCountdownIfRequired(player.getMatch());
+    if (countdown != null && countdown.contains(player.getId())) clearCountdown();
+    if (canCancel(player.getMatch())) startCountdownIfRequired(player.getMatch());
   }
 
   public void startCountdown(Match match, List<UUID> players, @Nullable Duration duration) {
@@ -61,9 +56,6 @@ public class CancelManager {
   }
 
   public void startCountdownIfRequired(Match match) {
-    // Check if countdown can be started
-    if (countdown != null || !canCancel(match)) return;
-
     // Check if countdown required for any participants
     PlayerWatcher.MatchParticipation participation =
         playerWatcher.getParticipations().values().stream()
@@ -74,8 +66,8 @@ public class CancelManager {
             .max(Comparator.comparing(PlayerWatcher.MatchParticipation::currentAbsentDuration))
             .orElse(null);
 
-    if (participation == null
-        || (countdown != null && countdown.players.contains(participation.getUUID()))) return;
+    if (participation == null || (countdown != null && countdown.contains(participation.getUUID())))
+      return;
 
     Duration duration =
         Ordering.natural()
@@ -133,12 +125,8 @@ public class CancelManager {
       duration--;
     }
 
-    public boolean isEmpty() {
-      return players.isEmpty();
-    }
-
-    public void removePlayer(UUID player) {
-      if (players.remove(player) && players.isEmpty()) cancelCountdown();
+    public boolean contains(UUID player) {
+      return players.contains(player);
     }
 
     public void cancelCountdown() {

--- a/src/main/java/rip/bolt/ingame/ranked/PlayerWatcher.java
+++ b/src/main/java/rip/bolt/ingame/ranked/PlayerWatcher.java
@@ -136,6 +136,7 @@ public class PlayerWatcher implements Listener {
     if (playersAbandoned(getNonJoinedPlayers())) {
       rankedManager.cancel(event.getMatch(), CancelReason.AUTOMATED_CANCEL);
       event.getMatch().sendMessage(Messages.matchStartCancelled());
+      return;
     }
 
     // Set everyone who is not online as "absent"

--- a/src/main/java/rip/bolt/ingame/ranked/PlayerWatcher.java
+++ b/src/main/java/rip/bolt/ingame/ranked/PlayerWatcher.java
@@ -14,6 +14,7 @@ import org.bukkit.event.player.PlayerLoginEvent;
 import rip.bolt.ingame.Ingame;
 import rip.bolt.ingame.api.definitions.Punishment;
 import rip.bolt.ingame.config.AppData;
+import rip.bolt.ingame.utils.CancelReason;
 import rip.bolt.ingame.utils.Messages;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.event.MatchFinishEvent;
@@ -22,7 +23,6 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.PlayerJoinMatchEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
-import tc.oc.pgm.result.TieVictoryCondition;
 
 public class PlayerWatcher implements Listener {
 
@@ -33,7 +33,6 @@ public class PlayerWatcher implements Listener {
   private final CancelManager cancelManager;
 
   private final Map<UUID, MatchParticipation> players = new HashMap<>();
-  private boolean automaticallyCancelled;
 
   public PlayerWatcher(RankedManager rankedManager) {
     this.rankedManager = rankedManager;
@@ -41,12 +40,15 @@ public class PlayerWatcher implements Listener {
     this.cancelManager = new CancelManager(this);
   }
 
+  public RankedManager getRankedManager() {
+    return rankedManager;
+  }
+
   public ForfeitManager getForfeitManager() {
     return forfeitManager;
   }
 
   public void addPlayers(List<UUID> uuids) {
-    automaticallyCancelled = false;
     players.clear();
     forfeitManager.clearPolls();
     cancelManager.clearCountdown();
@@ -105,22 +107,13 @@ public class PlayerWatcher implements Listener {
 
   @EventHandler(priority = EventPriority.LOW)
   public void onMatchEnd(MatchFinishEvent event) {
-    if (rankedManager.isManuallyCanceled()) return;
+    // If match was cancelled, don't bother with the rest
+    if (rankedManager.getCancelReason() != null) return;
 
-    // If a regular match end and duration less than max absent period no bans to check
-    if (!automaticallyCancelled && event.getMatch().getDuration().compareTo(ABSENT_MAX) > 0) return;
+    // Duration less than max absent period no bans to check
+    if (event.getMatch().getDuration().compareTo(ABSENT_MAX) > 0) return;
 
-    Duration maxAbsenceDuration =
-        (automaticallyCancelled) ? CancelManager.CANCEL_ABSENCE_LENGTH : ABSENT_MAX;
-
-    List<UUID> abandonedPlayers =
-        players.values().stream()
-            .filter(
-                participation -> participation.absentDuration().compareTo(maxAbsenceDuration) > 0)
-            .map(MatchParticipation::getUUID)
-            .collect(Collectors.toList());
-
-    if (playersAbandoned(abandonedPlayers)) {
+    if (playersAbandoned(getParticipationsBelowDuration(ABSENT_MAX))) {
       event.getMatch().sendMessage(Messages.participationBan());
     }
   }
@@ -140,7 +133,7 @@ public class PlayerWatcher implements Listener {
 
     // If a player never joined mark as abandoned
     if (playersAbandoned(getNonJoinedPlayers())) {
-      cancelMatch(event.getMatch());
+      rankedManager.cancel(event.getMatch(), CancelReason.AUTOMATED_CANCEL);
       event.getMatch().sendMessage(Messages.matchStartCancelled());
     }
 
@@ -151,14 +144,6 @@ public class PlayerWatcher implements Listener {
         });
 
     cancelManager.startCountdownIfRequired(event.getMatch());
-  }
-
-  public void cancelMatch(Match match) {
-    automaticallyCancelled = true;
-    // the order of these two lines should not be changed
-    rankedManager.postMatchStatus(match, MatchStatus.CANCELLED);
-    match.addVictoryCondition(new TieVictoryCondition());
-    match.finish();
   }
 
   public List<UUID> getNonJoinedPlayers() {
@@ -174,7 +159,14 @@ public class PlayerWatcher implements Listener {
         .collect(Collectors.toList());
   }
 
-  private boolean playersAbandoned(List<UUID> players) {
+  private List<UUID> getParticipationsBelowDuration(Duration minimumDuration) {
+    return players.values().stream()
+        .filter(participation -> participation.absentDuration().compareTo(minimumDuration) > 0)
+        .map(MatchParticipation::getUUID)
+        .collect(Collectors.toList());
+  }
+
+  public boolean playersAbandoned(List<UUID> players) {
     if (players.size() <= 5) {
       Integer seriesId = Ingame.get().getRankedManager().getMatch().getSeries().getId();
       players.forEach(player -> playerAbandoned(player, seriesId));

--- a/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
@@ -198,15 +198,13 @@ public class RankedManager implements Listener {
       match.getCountdown().cancelAll();
     }
 
-    // Add tie victory condition if in progress
-    boolean running = match.getPhase().canTransitionTo(MatchPhase.FINISHED);
-    if (running) {
+    // Check if match is in progress
+    if (match.getPhase().equals(MatchPhase.RUNNING)) {
+      // Add tie victory condition if in progress
       match.addVictoryCondition(new TieVictoryCondition());
       match.finish();
-    }
-
-    // Prompt players to requeue and start polling
-    if (!running) {
+    } else {
+      // Prompt players to requeue and start polling
       Audience.get(match.getCompetitors()).sendMessage(Messages.requeue());
       this.getPoll().startIn(Duration.ofSeconds(15));
     }

--- a/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
@@ -27,14 +27,19 @@ import rip.bolt.ingame.api.definitions.BoltMatch;
 import rip.bolt.ingame.api.definitions.Team;
 import rip.bolt.ingame.config.AppData;
 import rip.bolt.ingame.events.BoltMatchStatusChangeEvent;
+import rip.bolt.ingame.utils.CancelReason;
+import rip.bolt.ingame.utils.Messages;
 import rip.bolt.ingame.utils.PGMMapUtils;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchPhase;
 import tc.oc.pgm.api.match.event.MatchFinishEvent;
 import tc.oc.pgm.api.match.event.MatchLoadEvent;
 import tc.oc.pgm.api.match.event.MatchStartEvent;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.restart.RestartManager;
+import tc.oc.pgm.result.TieVictoryCondition;
+import tc.oc.pgm.util.Audience;
 
 public class RankedManager implements Listener {
 
@@ -50,7 +55,7 @@ public class RankedManager implements Listener {
   private BoltMatch match;
 
   private Duration cycleTime = Duration.ofSeconds(0);
-  private boolean manuallyCanceled;
+  private CancelReason cancelReason = null;
 
   public RankedManager(Plugin plugin) {
     playerWatcher = new PlayerWatcher(this);
@@ -71,7 +76,7 @@ public class RankedManager implements Listener {
     if (!this.isMatchValid(match)) return;
 
     this.match = match;
-    this.manuallyCanceled = false;
+    this.cancelReason = null;
     poll.stop();
 
     Tournament.get().getTeamManager().clear();
@@ -167,6 +172,10 @@ public class RankedManager implements Listener {
     return requeueManager;
   }
 
+  public CancelReason getCancelReason() {
+    return cancelReason;
+  }
+
   public void manualPoll(boolean repeat) {
     if (repeat) {
       poll.startIn(0L);
@@ -180,13 +189,27 @@ public class RankedManager implements Listener {
     this.match = null;
   }
 
-  public void manualCancel(Match match) {
-    this.manuallyCanceled = true;
+  public void cancel(Match match, CancelReason reason) {
+    this.cancelReason = reason;
     this.postMatchStatus(match, MatchStatus.CANCELLED);
-  }
 
-  public boolean isManuallyCanceled() {
-    return manuallyCanceled;
+    // Cancel countdowns if match has not started
+    if (match.getPhase().equals(MatchPhase.STARTING)) {
+      match.getCountdown().cancelAll();
+    }
+
+    // Add tie victory condition if in progress
+    boolean running = match.getPhase().canTransitionTo(MatchPhase.FINISHED);
+    if (running) {
+      match.addVictoryCondition(new TieVictoryCondition());
+      match.finish();
+    }
+
+    // Prompt players to requeue and start polling
+    if (!running) {
+      Audience.get(match.getCompetitors()).sendMessage(Messages.requeue());
+      this.getPoll().startIn(Duration.ofSeconds(15));
+    }
   }
 
   @EventHandler

--- a/src/main/java/rip/bolt/ingame/utils/CancelReason.java
+++ b/src/main/java/rip/bolt/ingame/utils/CancelReason.java
@@ -1,0 +1,6 @@
+package rip.bolt.ingame.utils;
+
+public enum CancelReason {
+  MANUAL_CANCEL,
+  AUTOMATED_CANCEL,
+}

--- a/src/main/java/rip/bolt/ingame/utils/Messages.java
+++ b/src/main/java/rip/bolt/ingame/utils/Messages.java
@@ -33,7 +33,8 @@ public class Messages {
   public static Component matchStartCancelled() {
     return text("Match could not be started due to lack of players.", NamedTextColor.RED)
         .append(newline())
-        .append(text("The offending players have received a temporary ban.", NamedTextColor.GRAY));
+        .append(
+            text("The offending player(s) have received a temporary ban.", NamedTextColor.GRAY));
   }
 
   public static Component participationBan() {


### PR DESCRIPTION
- Move cancel logic to RankedManager to share logic in command and automation
- Create cancel reason so null, manual, and automated become easier to share
- Switch order of cancel and messages so match ends and messages are sent after

Signed-off-by: Pugzy <pugzy@mail.com>