### PR TITLE
Switch to a less PGM dependent command framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
 			<artifactId>taskchain-bukkit</artifactId>
 			<version>3.7.2</version>
 		</dependency>
+        <dependency>
+            <groupId>co.aikar</groupId>
+            <artifactId>acf-bukkit</artifactId>
+            <version>0.5.0-SNAPSHOT</version>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/rip/bolt/ingame/commands/ForfeitCommands.java
+++ b/src/main/java/rip/bolt/ingame/commands/ForfeitCommands.java
@@ -2,6 +2,11 @@ package rip.bolt.ingame.commands;
 
 import static net.kyori.adventure.text.Component.text;
 
+import co.aikar.commands.BaseCommand;
+import co.aikar.commands.InvalidCommandArgument;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.Dependency;
+import co.aikar.commands.annotation.Description;
 import net.md_5.bungee.api.ChatColor;
 import rip.bolt.ingame.config.AppData;
 import rip.bolt.ingame.ranked.ForfeitManager;
@@ -10,43 +15,37 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchPhase;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.lib.app.ashcon.intake.Command;
-import tc.oc.pgm.lib.app.ashcon.intake.CommandException;
 
-public class ForfeitCommands {
+public class ForfeitCommands extends BaseCommand {
 
-  private final RankedManager ranked;
-  private final ForfeitManager forfeits;
+  @Dependency private RankedManager ranked;
+  @Dependency private ForfeitManager forfeits;
 
-  public ForfeitCommands(RankedManager ranked) {
-    this.ranked = ranked;
-    this.forfeits = this.ranked.getPlayerWatcher().getForfeitManager();
-  }
-
-  @Command(
-      aliases = {"forfeit", "ff"},
-      desc = "Accept that you have no chance of winning")
-  public void forfeit(MatchPlayer sender, Match match) throws CommandException {
+  @CommandAlias("forfeit|ff")
+  @Description("Accept that you have no chance of winning")
+  public void forfeit(MatchPlayer sender, Match match) {
     if (!AppData.forfeitEnabled())
-      throw new CommandException(
-          ChatColor.RED + "The forfeit command is not enabled on this server.");
+      throw new InvalidCommandArgument(
+          ChatColor.RED + "The forfeit command is not enabled on this server.", false);
 
     if (match.getPhase() != MatchPhase.RUNNING)
-      throw new CommandException(ChatColor.RED + "You may only run this command during a match.");
+      throw new InvalidCommandArgument(
+          ChatColor.RED + "You may only run this command during a match.", false);
 
     if (!(sender.getParty() instanceof Competitor))
-      throw new CommandException(
-          ChatColor.RED + "Only match players are able to run this command.");
+      throw new InvalidCommandArgument(
+          ChatColor.RED + "Only match players are able to run this command.", false);
 
     Competitor team = (Competitor) sender.getParty();
     if (!forfeits.mayForfeit(team))
-      throw new CommandException(
-          ChatColor.YELLOW + "It's too early to forfeit this match, you can still win!");
+      throw new InvalidCommandArgument(
+          ChatColor.YELLOW + "It's too early to forfeit this match, you can still win!", false);
 
     ForfeitManager.ForfeitPoll poll = forfeits.getForfeitPoll(team);
 
     if (poll.getVoted().contains(sender.getId()))
-      throw new CommandException(ChatColor.RED + "You have already voted to forfeit this match.");
+      throw new InvalidCommandArgument(
+          ChatColor.RED + "You have already voted to forfeit this match.", false);
 
     sender.sendMessage(text("You have voted to forfeit this match."));
     poll.addVote(sender);

--- a/src/main/java/rip/bolt/ingame/commands/RequeueCommands.java
+++ b/src/main/java/rip/bolt/ingame/commands/RequeueCommands.java
@@ -1,30 +1,29 @@
 package rip.bolt.ingame.commands;
 
+import co.aikar.commands.BaseCommand;
+import co.aikar.commands.InvalidCommandArgument;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.Dependency;
+import co.aikar.commands.annotation.Description;
 import net.md_5.bungee.api.ChatColor;
 import rip.bolt.ingame.Ingame;
 import rip.bolt.ingame.config.AppData;
 import rip.bolt.ingame.ranked.MatchStatus;
-import rip.bolt.ingame.ranked.RankedManager;
 import rip.bolt.ingame.ranked.RequeueManager;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchPhase;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.lib.app.ashcon.intake.Command;
-import tc.oc.pgm.lib.app.ashcon.intake.CommandException;
 
-public class RequeueCommands {
+public class RequeueCommands extends BaseCommand {
 
-  private final RequeueManager requeue;
+  @Dependency private RequeueManager requeue;
 
-  public RequeueCommands(RankedManager ranked) {
-    this.requeue = ranked.getRequeueManager();
-  }
-
-  @Command(aliases = "requeue", desc = "Requeue for another ranked match")
-  public void requeue(MatchPlayer sender, Match match) throws CommandException {
+  @CommandAlias("requeue")
+  @Description("Requeue for another ranked match")
+  public void requeue(MatchPlayer sender, Match match) {
     if (!AppData.allowRequeue()) {
-      throw new CommandException(
-          ChatColor.RED + "The requeue command is not enabled on this server.");
+      throw new InvalidCommandArgument(
+          ChatColor.RED + "The requeue command is not enabled on this server.", false);
     }
 
     boolean finished = match.getPhase() == MatchPhase.FINISHED;
@@ -32,8 +31,8 @@ public class RequeueCommands {
         Ingame.get().getRankedManager().getMatch().getStatus().equals(MatchStatus.CANCELLED);
 
     if (!(finished || cancelled))
-      throw new CommandException(
-          ChatColor.RED + "You may only run this command after a match has ended.");
+      throw new InvalidCommandArgument(
+          ChatColor.RED + "You may only run this command after a match has ended.", false);
 
     requeue.requestRequeue(sender);
   }


### PR DESCRIPTION
This PR switches from [intake](https://github.com/Electroid/intake) to [acf](https://github.com/aikar/commands), a much more flexible and less PGM-dependent framework. 

The only difference with acf is the lack of command flags, impacting the `/ingame poll -r` command. I've set it to now accept a boolean so `/ingame poll true` would replicate the existing function. However alternative workarounds are available, such as having the last argument be a String and simply checking if the user input equals `-r`, though I find that solution not too elegant. 

If there's any suggestions/feedback please let me know and I'll be happy to make changes where applicable 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>