### PR TITLE
Fix team swapping or blitz death joining obs in pugs

### DIFF
--- a/src/main/java/rip/bolt/ingame/managers/GameManager.java
+++ b/src/main/java/rip/bolt/ingame/managers/GameManager.java
@@ -8,6 +8,7 @@ import org.bukkit.event.Listener;
 import org.jetbrains.annotations.Nullable;
 import rip.bolt.ingame.Ingame;
 import rip.bolt.ingame.api.definitions.BoltMatch;
+import rip.bolt.ingame.api.definitions.Series;
 import rip.bolt.ingame.pugs.PugManager;
 import rip.bolt.ingame.ranked.RankedManager;
 
@@ -50,7 +51,11 @@ public abstract class GameManager implements Listener {
     Bukkit.getPluginManager().registerEvents(this, Ingame.get());
   }
 
-  public abstract void setup(BoltMatch match);
+  public void setup(@Nullable BoltMatch match) {
+    boolean allowSpectators =
+        (match != null && match.getSeries().getService() != Series.Service.TM);
+    EventsPlugin.get().getConfig().set("allow-spectators", allowSpectators);
+  }
 
   /** Called when the game manager is removed. */
   public void disable() {
@@ -67,6 +72,7 @@ public abstract class GameManager implements Listener {
 
     @Override
     public void setup(BoltMatch match) {
+      super.setup(match);
       EventsPlugin.get().getTeamManager().clear();
       EventsPlugin.get().getTournamentManager().deleteTournament();
     }

--- a/src/main/java/rip/bolt/ingame/pugs/PugListener.java
+++ b/src/main/java/rip/bolt/ingame/pugs/PugListener.java
@@ -134,7 +134,7 @@ public class PugListener implements Listener {
     Party nextParty = event.getNextParty();
 
     if (nextParty instanceof Competitor) {
-      PugTeam team = pugManager.findPugTeam(event.getCompetitor());
+      PugTeam team = pugManager.findPugTeam(nextParty);
       if (team != null) pugManager.write(PugCommand.joinTeam(event.getPlayer().getBukkit(), team));
     } else if (nextParty != null) {
       pugManager.write(PugCommand.joinObs(event.getPlayer().getBukkit()));

--- a/src/main/java/rip/bolt/ingame/pugs/PugManager.java
+++ b/src/main/java/rip/bolt/ingame/pugs/PugManager.java
@@ -83,6 +83,7 @@ public class PugManager extends GameManager {
 
   @Override
   public void setup(BoltMatch match) {
+    super.setup(match);
     if (this.pugLobby != null) teamManager.setupTeams(match);
   }
 

--- a/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
@@ -47,6 +47,7 @@ public class RankedManager extends GameManager {
 
   @Override
   public void setup(BoltMatch match) {
+    super.setup(match);
     EventsPlugin.get().getTeamManager().clear();
     for (TournamentTeam team : match.getTeams()) EventsPlugin.get().getTeamManager().addTeam(team);
     playerWatcher.addPlayers(


### PR DESCRIPTION
Makes it so joining straight from a team to another doesn't accidentally leave you in obs, additionally, makes it so blitz making you leave the pgm team doesn't make you leave the pug team, so you'll be included in stats and stay in when cycling.

Requires https://github.com/PGMDev/PGM/pull/1175