### PR TITLE
Add managers for Nicks and Kick messages

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     compileOnly("org.incendo:cloud-annotations:2.0.0")
     compileOnly("org.jetbrains:annotations:26.0.2-1")
     compileOnly("com.google.guava:guava:17.0")
+    compileOnly("dev.pgm.community:core:0.2-SNAPSHOT")
 }
 
 group = "rip.bolt"

--- a/src/main/java/rip/bolt/ingame/managers/KickMessageManager.java
+++ b/src/main/java/rip/bolt/ingame/managers/KickMessageManager.java
@@ -1,0 +1,32 @@
+package rip.bolt.ingame.managers;
+
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerKickEvent;
+import rip.bolt.ingame.api.definitions.BoltMatch;
+import rip.bolt.ingame.config.AppData;
+import rip.bolt.ingame.utils.Messages;
+import tc.oc.pgm.util.Audience;
+
+public class KickMessageManager implements Listener {
+
+  private static final LegacyComponentSerializer SERIALIZER =
+      LegacyComponentSerializer.legacySection();
+
+  private final MatchManager matchManager;
+
+  public KickMessageManager(MatchManager matchManager) {
+    this.matchManager = matchManager;
+  }
+
+  @EventHandler(priority = EventPriority.NORMAL)
+  public void onPlayerKick(PlayerKickEvent event) {
+    BoltMatch match = matchManager.getMatch();
+    if (match == null || match.getStatus().isFinished() || match.getTeams() == null) return;
+    if (match.getParticipation(event.getPlayer().getUniqueId()) == null) return;
+
+    Audience.get(event.getPlayer()).sendMessage(Messages.rejoinServer(AppData.getServerName()));
+  }
+}

--- a/src/main/java/rip/bolt/ingame/managers/KickMessageManager.java
+++ b/src/main/java/rip/bolt/ingame/managers/KickMessageManager.java
@@ -27,6 +27,7 @@ public class KickMessageManager implements Listener {
     if (match == null || match.getStatus().isFinished() || match.getTeams() == null) return;
     if (match.getParticipation(event.getPlayer().getUniqueId()) == null) return;
 
-    Audience.get(event.getPlayer()).sendMessage(Messages.rejoinServer(AppData.getServerName()));
+    Audience.get(event.getPlayer())
+        .sendMessage(Messages.withSeparators(Messages.rejoinServer(AppData.getServerName())));
   }
 }

--- a/src/main/java/rip/bolt/ingame/managers/KickMessageManager.java
+++ b/src/main/java/rip/bolt/ingame/managers/KickMessageManager.java
@@ -5,6 +5,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.plugin.Plugin;
 import rip.bolt.ingame.api.definitions.BoltMatch;
 import rip.bolt.ingame.config.AppData;
 import rip.bolt.ingame.utils.Messages;
@@ -17,8 +18,9 @@ public class KickMessageManager implements Listener {
 
   private final MatchManager matchManager;
 
-  public KickMessageManager(MatchManager matchManager) {
+  public KickMessageManager(MatchManager matchManager, Plugin plugin) {
     this.matchManager = matchManager;
+    plugin.getServer().getPluginManager().registerEvents(this, plugin);
   }
 
   @EventHandler(priority = EventPriority.NORMAL)

--- a/src/main/java/rip/bolt/ingame/managers/MatchManager.java
+++ b/src/main/java/rip/bolt/ingame/managers/MatchManager.java
@@ -77,6 +77,8 @@ public class MatchManager implements Listener {
     battlepassManager = BattlepassUtils.createManager();
 
     Bukkit.getPluginManager().registerEvents(this, plugin);
+    Bukkit.getPluginManager().registerEvents(new KickMessageManager(this), plugin);
+
     if (Platform.VARIANT == Supports.Variant.SPORTPAPER) {
       Bukkit.getPluginManager().registerEvents(new KnockbackManager(), plugin);
     }

--- a/src/main/java/rip/bolt/ingame/managers/MatchManager.java
+++ b/src/main/java/rip/bolt/ingame/managers/MatchManager.java
@@ -32,6 +32,7 @@ import rip.bolt.ingame.setup.MatchSearch;
 import rip.bolt.ingame.utils.BattlepassUtils;
 import rip.bolt.ingame.utils.CancelReason;
 import rip.bolt.ingame.utils.Messages;
+import rip.bolt.ingame.utils.NickUtils;
 import rip.bolt.ingame.utils.PGMMapUtils;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
@@ -52,8 +53,6 @@ import tc.oc.pgm.util.platform.Supports;
 public class MatchManager implements Listener {
 
   private final StatsManager statsManager;
-  private final TabManager tabManager;
-  private final BattlepassManager battlepassManager;
 
   private final MatchSearch poll;
 
@@ -73,11 +72,13 @@ public class MatchManager implements Listener {
   public MatchManager(Plugin plugin) {
     gameManager = new GameManager.NoopManager(this);
     statsManager = new StatsManager();
-    tabManager = new TabManager(plugin);
-    battlepassManager = BattlepassUtils.createManager();
+    new TabManager(plugin);
+    BattlepassUtils.createManager();
+
+    NickUtils.createManager(plugin);
+    new KickMessageManager(this, plugin);
 
     Bukkit.getPluginManager().registerEvents(this, plugin);
-    Bukkit.getPluginManager().registerEvents(new KickMessageManager(this), plugin);
 
     if (Platform.VARIANT == Supports.Variant.SPORTPAPER) {
       Bukkit.getPluginManager().registerEvents(new KnockbackManager(), plugin);

--- a/src/main/java/rip/bolt/ingame/managers/NickManager.java
+++ b/src/main/java/rip/bolt/ingame/managers/NickManager.java
@@ -1,41 +1,35 @@
-package rip.bolt.ingame.ranked;
-
-import static net.kyori.adventure.text.Component.text;
+package rip.bolt.ingame.managers;
 
 import dev.pgm.community.Community;
 import dev.pgm.community.nick.feature.NickFeature;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import rip.bolt.ingame.Ingame;
-import rip.bolt.ingame.ranked.forfeit.PlayerWatcher;
 import rip.bolt.ingame.utils.Messages;
 import tc.oc.pgm.api.event.NameDecorationChangeEvent;
 import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.PlayerJoinMatchEvent;
 
 public class NickManager implements Listener {
 
-  private final PlayerWatcher watcher;
-
-  public NickManager(PlayerWatcher playerWatcher) {
-    this.watcher = playerWatcher;
-  }
+  public NickManager() {}
 
   @EventHandler(priority = EventPriority.NORMAL)
   public void onPlayerJoinMatch(PlayerJoinMatchEvent event) {
     MatchPlayer player = event.getPlayer();
 
-    UUID playerId = player.getId();
-    if (!watcher.isPlaying(playerId)) return;
+    if (!(event.getNewParty() instanceof Competitor)) return;
     if (Ingame.get().getMatchManager().getMatch() == null) return;
     if (Integration.getNick(player.getBukkit()) == null) return;
+
+    UUID playerId = player.getId();
 
     NickFeature nick = Community.get().getFeatures().getNick();
 
@@ -47,10 +41,6 @@ public class NickManager implements Listener {
     event
         .getMatch()
         .getExecutor(MatchScope.LOADED)
-        .schedule(
-            () -> player.sendMessage(Messages.withSeparators(text(
-                "Your nick was removed as you are playing in this match.", NamedTextColor.RED))),
-            2,
-            TimeUnit.SECONDS);
+        .schedule(() -> player.sendMessage(Messages.nickRemoved()), 2, TimeUnit.SECONDS);
   }
 }

--- a/src/main/java/rip/bolt/ingame/ranked/NickManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/NickManager.java
@@ -13,6 +13,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import rip.bolt.ingame.Ingame;
 import rip.bolt.ingame.ranked.forfeit.PlayerWatcher;
+import rip.bolt.ingame.utils.Messages;
 import tc.oc.pgm.api.event.NameDecorationChangeEvent;
 import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.match.MatchScope;
@@ -47,8 +48,8 @@ public class NickManager implements Listener {
         .getMatch()
         .getExecutor(MatchScope.LOADED)
         .schedule(
-            () -> player.sendMessage(text(
-                "Your nick was removed as you are playing in this match.", NamedTextColor.RED)),
+            () -> player.sendMessage(Messages.withSeparators(text(
+                "Your nick was removed as you are playing in this match.", NamedTextColor.RED))),
             2,
             TimeUnit.SECONDS);
   }

--- a/src/main/java/rip/bolt/ingame/ranked/NickManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/NickManager.java
@@ -1,0 +1,55 @@
+package rip.bolt.ingame.ranked;
+
+import static net.kyori.adventure.text.Component.text;
+
+import dev.pgm.community.Community;
+import dev.pgm.community.nick.feature.NickFeature;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import rip.bolt.ingame.Ingame;
+import rip.bolt.ingame.ranked.forfeit.PlayerWatcher;
+import tc.oc.pgm.api.event.NameDecorationChangeEvent;
+import tc.oc.pgm.api.integration.Integration;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.events.PlayerJoinMatchEvent;
+
+public class NickManager implements Listener {
+
+  private final PlayerWatcher watcher;
+
+  public NickManager(PlayerWatcher playerWatcher) {
+    this.watcher = playerWatcher;
+  }
+
+  @EventHandler(priority = EventPriority.NORMAL)
+  public void onPlayerJoinMatch(PlayerJoinMatchEvent event) {
+    MatchPlayer player = event.getPlayer();
+
+    UUID playerId = player.getId();
+    if (!watcher.isPlaying(playerId)) return;
+    if (Ingame.get().getMatchManager().getMatch() == null) return;
+    if (Integration.getNick(player.getBukkit()) == null) return;
+
+    NickFeature nick = Community.get().getFeatures().getNick();
+
+    nick.removeOnlineNick(playerId);
+
+    Bukkit.getPluginManager().callEvent(new NameDecorationChangeEvent(playerId));
+
+    // Delay so message appears after Community nick message
+    event
+        .getMatch()
+        .getExecutor(MatchScope.LOADED)
+        .schedule(
+            () -> player.sendMessage(text(
+                "Your nick was removed as you are playing in this match.", NamedTextColor.RED)),
+            2,
+            TimeUnit.SECONDS);
+  }
+}

--- a/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
@@ -28,7 +28,6 @@ public class RankedManager extends GameManager {
   private final RankManager rankManager;
   private final SpectatorManager spectatorManager;
   private final RequeueManager requeueManager;
-  private final NickManager nickManager;
 
   public RankedManager(MatchManager matchManager) {
     super(matchManager);
@@ -37,7 +36,6 @@ public class RankedManager extends GameManager {
     this.rankManager = new RankManager(matchManager);
     this.spectatorManager = new SpectatorManager(playerWatcher);
     this.requeueManager = new RequeueManager();
-    this.nickManager = new NickManager(playerWatcher);
   }
 
   @Override
@@ -48,15 +46,16 @@ public class RankedManager extends GameManager {
     Bukkit.getPluginManager().registerEvents(this.rankManager, Ingame.get());
     Bukkit.getPluginManager().registerEvents(this.spectatorManager, Ingame.get());
     Bukkit.getPluginManager().registerEvents(this.requeueManager, Ingame.get());
-    Bukkit.getPluginManager().registerEvents(this.nickManager, Ingame.get());
   }
 
   @Override
   public void setup(BoltMatch match) {
     super.setup(match);
     EventsPlugin.get().getTeamManager().clear();
-    for (TournamentTeam team : match.getTeams())
+    for (TournamentTeam team : match.getTeams()) {
       EventsPlugin.get().getTeamManager().addTeam(team);
+    }
+
     playerWatcher.addPlayers(match.getTeams().stream()
         .flatMap(team -> team.getPlayers().stream())
         .map(TournamentPlayer::getUUID)
@@ -70,7 +69,6 @@ public class RankedManager extends GameManager {
     HandlerList.unregisterAll(this.rankManager);
     HandlerList.unregisterAll(this.spectatorManager);
     HandlerList.unregisterAll(this.requeueManager);
-    HandlerList.unregisterAll(this.nickManager);
   }
 
   public PlayerWatcher getPlayerWatcher() {

--- a/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
+++ b/src/main/java/rip/bolt/ingame/ranked/RankedManager.java
@@ -28,6 +28,7 @@ public class RankedManager extends GameManager {
   private final RankManager rankManager;
   private final SpectatorManager spectatorManager;
   private final RequeueManager requeueManager;
+  private final NickManager nickManager;
 
   public RankedManager(MatchManager matchManager) {
     super(matchManager);
@@ -36,6 +37,7 @@ public class RankedManager extends GameManager {
     this.rankManager = new RankManager(matchManager);
     this.spectatorManager = new SpectatorManager(playerWatcher);
     this.requeueManager = new RequeueManager();
+    this.nickManager = new NickManager(playerWatcher);
   }
 
   @Override
@@ -46,18 +48,19 @@ public class RankedManager extends GameManager {
     Bukkit.getPluginManager().registerEvents(this.rankManager, Ingame.get());
     Bukkit.getPluginManager().registerEvents(this.spectatorManager, Ingame.get());
     Bukkit.getPluginManager().registerEvents(this.requeueManager, Ingame.get());
+    Bukkit.getPluginManager().registerEvents(this.nickManager, Ingame.get());
   }
 
   @Override
   public void setup(BoltMatch match) {
     super.setup(match);
     EventsPlugin.get().getTeamManager().clear();
-    for (TournamentTeam team : match.getTeams()) EventsPlugin.get().getTeamManager().addTeam(team);
-    playerWatcher.addPlayers(
-        match.getTeams().stream()
-            .flatMap(team -> team.getPlayers().stream())
-            .map(TournamentPlayer::getUUID)
-            .collect(Collectors.toList()));
+    for (TournamentTeam team : match.getTeams())
+      EventsPlugin.get().getTeamManager().addTeam(team);
+    playerWatcher.addPlayers(match.getTeams().stream()
+        .flatMap(team -> team.getPlayers().stream())
+        .map(TournamentPlayer::getUUID)
+        .collect(Collectors.toList()));
   }
 
   @Override
@@ -67,6 +70,7 @@ public class RankedManager extends GameManager {
     HandlerList.unregisterAll(this.rankManager);
     HandlerList.unregisterAll(this.spectatorManager);
     HandlerList.unregisterAll(this.requeueManager);
+    HandlerList.unregisterAll(this.nickManager);
   }
 
   public PlayerWatcher getPlayerWatcher() {
@@ -96,15 +100,9 @@ public class RankedManager extends GameManager {
     if (event.getOldStatus() == MatchStatus.CREATED
         && event.getNewStatus().equals(MatchStatus.LOADED)) {
       TournamentTeamManager teamManager = EventsPlugin.get().getTeamManager();
-      event
-          .getBoltMatch()
-          .getTeams()
-          .forEach(
-              boltTeam ->
-                  teamManager
-                      .fromTournamentTeam(boltTeam)
-                      .ifPresent(
-                          team -> team.setMaxSize(boltTeam.getParticipations().size(), null)));
+      event.getBoltMatch().getTeams().forEach(boltTeam -> teamManager
+          .fromTournamentTeam(boltTeam)
+          .ifPresent(team -> team.setMaxSize(boltTeam.getParticipations().size(), null)));
     }
   }
 

--- a/src/main/java/rip/bolt/ingame/utils/Messages.java
+++ b/src/main/java/rip/bolt/ingame/utils/Messages.java
@@ -72,6 +72,11 @@ public class Messages {
         .append(separatorLine());
   }
 
+  public static Component nickRemoved() {
+    return withSeparators(
+        text("Your nick was removed as you are playing in this match.", NamedTextColor.RED));
+  }
+
   public static Component profileLink(MatchPlayer player) {
     String url = AppData.Web.getProfileLink().replace("{name}", player.getNameLegacy());
 

--- a/src/main/java/rip/bolt/ingame/utils/Messages.java
+++ b/src/main/java/rip/bolt/ingame/utils/Messages.java
@@ -57,6 +57,21 @@ public class Messages {
         .append(link(Style.style(NamedTextColor.BLUE, TextDecoration.UNDERLINED), url));
   }
 
+  public static Component separatorLine() {
+    return text(
+        "                                                                           ",
+        Style.style(NamedTextColor.GRAY, TextDecoration.STRIKETHROUGH));
+  }
+
+  public static Component withSeparators(Component content) {
+    return text("")
+        .append(separatorLine())
+        .append(newline())
+        .append(content)
+        .append(newline())
+        .append(separatorLine());
+  }
+
   public static Component profileLink(MatchPlayer player) {
     String url = AppData.Web.getProfileLink().replace("{name}", player.getNameLegacy());
 

--- a/src/main/java/rip/bolt/ingame/utils/Messages.java
+++ b/src/main/java/rip/bolt/ingame/utils/Messages.java
@@ -33,6 +33,12 @@ public class Messages {
                 command(Style.style(NamedTextColor.YELLOW, TextDecoration.UNDERLINED), "forfeit")));
   }
 
+  public static Component rejoinServer(String serverName) {
+    return text("You can rejoin the match by running ", NamedTextColor.GREEN)
+        .append(command(
+            Style.style(NamedTextColor.YELLOW, TextDecoration.UNDERLINED), "server", serverName));
+  }
+
   public static Component matchStartCancelled() {
     return text("Match could not be started due to lack of players.", NamedTextColor.RED)
         .append(newline())

--- a/src/main/java/rip/bolt/ingame/utils/NickUtils.java
+++ b/src/main/java/rip/bolt/ingame/utils/NickUtils.java
@@ -1,0 +1,13 @@
+package rip.bolt.ingame.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+import rip.bolt.ingame.managers.NickManager;
+
+public class NickUtils {
+
+  public static void createManager(Plugin plugin) {
+    if (!Bukkit.getPluginManager().isPluginEnabled("Community")) return;
+    plugin.getServer().getPluginManager().registerEvents(new NickManager(), plugin);
+  }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,4 +4,4 @@ version: ${version} (git-${commitHash})
 api-version: ${apiVersion}
 website: ${url}
 depend: [PGM, Events]
-softdepend: [Dispense]
+softdepend: [Dispense, Community]


### PR DESCRIPTION
Adds two cross-service listener managers: one to strip Community nicks from match participants, one to send a rejoin message to players who are kicked mid-match.

### NickManager
- Removes a player's Community nick when they join a match as a participant
- Uses `isPluginEnabled("Community")` guard via `NickUtils` so the plugin loads cleanly without Community present
- Checks `event.getNewParty() instanceof Competitor` instead of a ranked-specific player list, making it work across all service types (RANKED, PUG, TM, DRAFT)
- Registered globally in `MatchManager` rather than scoped to `RankedManager`

### KickMessageManager
- Sends a rejoin server message (with separators) to participants who are kicked from the server during a match
- Registered globally in `MatchManager`
- Allows players who were kicked for being idle/afk to rejoin with a message click